### PR TITLE
Expand provider config for all providers.

### DIFF
--- a/ipa/ipa_ec2.py
+++ b/ipa/ipa_ec2.py
@@ -20,8 +20,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-
 import boto3
 
 from ipa import ipa_utils
@@ -77,9 +75,7 @@ class EC2Provider(IpaProvider):
                                           running_instance_id,
                                           test_dirs,
                                           test_files)
-        config_file = os.path.expanduser(
-            self.provider_config or EC2_CONFIG_FILE
-        )
+        config_file = self.provider_config or EC2_CONFIG_FILE
 
         if not account_name:
             raise EC2ProviderException(

--- a/ipa/ipa_provider.py
+++ b/ipa/ipa_provider.py
@@ -108,9 +108,11 @@ class IpaProvider(object):
             default=IPA_HISTORY_FILE
         )
 
-        self.provider_config = self._get_value(
-            provider_config,
-            config_key='provider_config'
+        self.provider_config = os.path.expanduser(
+            self._get_value(
+                provider_config,
+                config_key='provider_config'
+            )
         )
 
         self.region = self._get_value(


### PR DESCRIPTION
- The expand user should be in base class init. This covers all providers instead of just EC2.