### PR TITLE
Add docs

### DIFF
--- a/CHANGES.asciidoc
+++ b/CHANGES.asciidoc
@@ -1,0 +1,5 @@
+= Changelog
+
+== v0.0.1 (2017-08-15)
+
+- Initial release.

--- a/CONTRIBUTING.asciidoc
+++ b/CONTRIBUTING.asciidoc
@@ -1,6 +1,7 @@
 = Contributing to ipa
+:toc:
 
-=== Installation
+== Installation
 
 [source]
 ----
@@ -15,12 +16,12 @@ pip install -e .[dev]
 ipa is now installed in the active virtual environment in development
 mode.
 
-=== Dev Requirements
+== Dev Requirements
 
 * bumpversion
 * pip>=7.0.0
 
-=== Testing Requirements
+== Testing Requirements
 
 * coverage
 * flake8
@@ -28,7 +29,7 @@ mode.
 * pytest-cov
 * vcrpy
 
-=== Contribution Checklist
+== Contribution Checklist
 
 * All patches must be signed. <<Signing Commits>>
 * All contributed code must conform to flake8. <<Code Style>>
@@ -36,7 +37,7 @@ mode.
 ** Tests must pass and coverage remain above 90%. <<Unit & Integration Tests>>
 * Follow Semantic Versioning. <<Versions & Releases>>
 
-=== Versions & Releases
+== Versions & Releases
 
 *ipa* adheres to Semantic versioning; see http://semver.org/ for details.
 
@@ -48,7 +49,7 @@ bumpversion major|minor|patch
 git push && git push --tags
 ----
 
-=== Unit & Integration Tests
+== Unit & Integration Tests
 
 All tests should pass and test coverage should remain above 90%.
 
@@ -58,14 +59,14 @@ The tests and coverage can be run directly via pytest.
 pytest --cov=ipa
 ----
 
-=== Testing with tox
+== Testing with tox
 
-==== Requirements
+=== Requirements
 
 * tox
 * tox-pyenv (testing multiple Python versions 3.4+)
 
-==== Setup
+=== Setup
 
 * Install tox
 +
@@ -86,7 +87,7 @@ tox -e py{version}
 tox -e py36
 ----
 
-=== Code Style
+== Code Style
 
 Source should pass flake8 and pep8 standards.
 
@@ -94,7 +95,7 @@ Source should pass flake8 and pep8 standards.
 flake8 ipa
 ----
 
-=== Signing Commits
+== Signing Commits
 
 The repository and the code base patches sent for inclusion must be GPG signed.
 See the GitHub article,

--- a/CONTRIBUTING.asciidoc
+++ b/CONTRIBUTING.asciidoc
@@ -95,6 +95,24 @@ Source should pass flake8 and pep8 standards.
 flake8 ipa
 ----
 
+== Man Pages
+
+If the CLI is changed the man pages can be auto-generated.
+
+* Install click-man
++
+----
+pip install click-man
+----
+
+* Generate man pages
++
+----
+python3 setup.py \
+  --command-packages=click_man.commands man_pages \
+  --target man/man1
+----
+
 == Signing Commits
 
 The repository and the code base patches sent for inclusion must be GPG signed.

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -15,7 +15,7 @@ To install the package use the following commands as root:
 ----
 zypper ar http://download.opensuse.org/repositories/Cloud:/Tools/<distribution>
 zypper refresh
-zypper in python-ipa
+zypper in python3-ipa
 ----
 
 === Requirements
@@ -99,5 +99,5 @@ See link:CONTRIBUTING.asciidoc[CONTRIBUTING] for info on getting started.
 
 Copyright (c) 2017 SUSE LLC.
 
-Distributed under the terms of GPL-3.0 license, see
+Distributed under the terms of GPL-3.0+ license, see
 link:LICENSE[LICENSE] for details.

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,4 +1,5 @@
 = ipa
+:toc:
 
 *ipa* (Image Proofing App)
 
@@ -7,7 +8,7 @@
 *ipa* provides a command line utility to test images in the
 Public Cloud (AWS, Azure, GCE, etc.).
 
-=== Installation
+== Installation
 
 To install the package use the following commands as root:
 
@@ -18,7 +19,7 @@ zypper refresh
 zypper in python3-ipa
 ----
 
-=== Requirements
+== Requirements
 
 * azurectl
 * boto3
@@ -28,9 +29,9 @@ zypper in python3-ipa
 * PyYaml
 * testinfra
 
-=== Config
+== Configuration
 
-The framework config is ini format ~/.config/ipa/config. Anything
+The framework configuration is ini format ~/.config/ipa/config. Anything
 specific to the test framework can be found in this file. Thus anything
 that is cloud framework independent such as the test dir and results dir.
 
@@ -44,20 +45,20 @@ results=~/ipa/results/
 region=us-west-1
 ----
 
-=== Azure Config
+=== Azure Configuration
 
-*ipa* shares the azurectl config file. See the
+*ipa* shares the azurectl configuration file. See the
 link:https://github.com/SUSE/azurectl#configuration-file[azurectl readme] for
 more info on the location and format.
 
-=== EC2 Config
+=== EC2 Configuration
 
-For testing EC2 instances *ipa* will use the ec2utils config file located at
-~/.ec2utils.conf. See
+For testing EC2 instances *ipa* will use the ec2utils configuration file
+located at ~/.ec2utils.conf. See
 link:https://github.com/SUSE/Enceladus/tree/master/ec2utils[ec2utils] for an
-example config file.
+example configuration file.
 
-=== Tests
+== Tests
 
 *ipa* uses the Testinfra package for writing unit tests. Testinfra leverages
 Pytest and provides modules such as Package, Process and Service to test the
@@ -72,7 +73,7 @@ as `--early-exit`. If there's an interest or need for any other options/args
 please submit an issue to link:https://github.com/SUSE/ipa/issues[Github].
 ====
 
-=== CLI Overview
+== CLI Overview
 
 The CLI provides multiple subcommands to initiate image testing:
 
@@ -85,17 +86,17 @@ Print test results info.
 `ipa list`::
 Print a list of test files or test cases.
 
-=== Issues/Enhancements
+== Issues/Enhancements
 
 Please submit issues and requests to
 link:https://github.com/SUSE/ipa/issues[Github].
 
-=== Contributing
+== Contributing
 
 Contributions to *ipa* are welcome and encouraged.
 See link:CONTRIBUTING.asciidoc[CONTRIBUTING] for info on getting started.
 
-=== License
+== License
 
 Copyright (c) 2017 SUSE LLC.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,0 +1,7 @@
+= *ipa* Docs
+
+== Contents
+
+* link:start.asciidoc[Getting Started]
+* link:tests.asciidoc[Writing Tests]
+* link:source.asciidoc[Source Overview]

--- a/docs/source.asciidoc
+++ b/docs/source.asciidoc
@@ -1,0 +1,104 @@
+= ipa Source Overview
+:toc:
+
+== CLI
+
+ ipa test
+
+The test subcommand invokes a test suite on an image in the chosen
+public cloud environment. The image id, tests and provider are required
+arguments. See below for options:
+
+----
+Example: ipa test --ssh-private-key /path/to/key -d SLES Azure test_image
+----
+
+ ipa results
+
+The results subcommand displays the test results information. The path
+to the results xml is required.
+
+----
+Example: ipa results -v
+----
+
+The default location for results files is ~/ipa/results/ and the files
+are encoded with the timestamp of execution. For example,
+the results for an image test in ec2 would be found at
+~/ipa/results/ec2/{imageId}/{instanceId}/{datetime}.results.
+
+----
+Example results directory:
+
+ec2/:
+  ami-43243232/:
+    i-3432r4324y3t2/:
+      {datetime}.results
+    i-432423j3j2432/:
+      {datetime}.results
+----
+
+ ipa list
+
+The list subcommand displays the available tests.
+
+----
+Examples: ipa list
+----
+
+The list subcommand will return a list of test files in the default test
+directories. The verbose option will return a list of all available
+tests in all test files.
+
+----
+Example output:
+
+$ ipa list -v
+
+test_broken::test_broken
+test_image::test_image
+test_sles::test_sles
+test_sles::test_sles_1
+test_sles::test_sles_2
+----
+
+== API
+
+The API used by CLI or used independently, is structured with a base
+class in ipa_provider.py. This contains the functionality required to run tests
+and collect the test results.
+
+[source,python]
+.ipa_provider.py
+----
+class IpaProvider(object):
+...
+----
+
+The base class is extended for each provider to implement specific
+methods for manipulating the test instance.
+
+[source,python]
+.ipa_{cloud-provider}.py
+----
+class {CloudProvider}Provider(IpaProvider):
+...
+----
+
+The controller (ipa_controller.py) provides methods for testing an image,
+displaying available tests and/or test files and displaying results of a
+previous test run. These methods provide a layer between the CLI and the
+API. They also provide an entry point for using *ipa* directly from code.
+
+[source,python]
+.ipa_controller.py
+----
+def test_image(self):
+    """Creates a cloud provider instance and initiates testing."""
+
+def list_tests(self):
+    """Returns a list of test files and/or tests."""
+
+def collect_results(self):
+    """Returns the result (pass/fail) or verbose results."""
+----

--- a/docs/start.asciidoc
+++ b/docs/start.asciidoc
@@ -89,8 +89,12 @@ Test image in the given framework using the supplied test files.
 ----
 # Testing an image in EC2
 
-> ipa test -i {image-id} -a {account} --provider-config ~/.ec2utils.conf \
-> --no-cleanup -d openSUSE_Leap EC2 test_image
+> ipa test -i {image-id} \
+  -a {account} \
+  --provider-config ~/.ec2utils.conf \
+  --no-cleanup \
+  -d openSUSE_Leap \
+  EC2 test_image
 
 Starting instance
 Running tests /home/{user}/ipa/tests/test_image.py
@@ -98,8 +102,11 @@ PASSED tests=1|pass=1|fail=0|error=0
 
 # Testing an image in Azure
 
-> ipa test -i {image-id} --no-cleanup -d openSUSE_Leap \
-> --ssh-private-key {azure-ssh-key-file} Azure test_image
+> ipa test -i {image-id} \
+  --no-cleanup \
+  -d openSUSE_Leap \
+  --ssh-private-key {azure-ssh-key-file} \
+  Azure test_image
 
 Starting instance
 Running tests /home/{user}/ipa/tests/test_image.py

--- a/docs/start.asciidoc
+++ b/docs/start.asciidoc
@@ -1,0 +1,167 @@
+= Getting Started
+:toc:
+
+=== Requirements
+
+* azurectl
+* boto3
+* Click
+* paramiko
+* pytest
+* PyYaml
+* testinfra
+
+== Installation
+
+To install the package use the following commands as root:
+
+[source]
+----
+zypper ar http://download.opensuse.org/repositories/Cloud:/Tools/<distribution>
+zypper refresh
+zypper in python-ipa
+----
+
+Or you can install the latest development version from github:
+
+[source]
+----
+# latest source
+pip install git+https://github.com/SUSE/ipa.git
+
+# specific branch or release
+pip install git+https://github.com/SUSE/ipa.git@{branch/release}
+----
+
+See
+link:https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support[PyPi docs]
+for more information on vcs support.
+
+== Configuration
+
+The framework configuration file is ini format ~/.config/ipa/config. Anything
+specific to the test framework can be found in this file. Thus anything
+that is cloud framework independent such as the tests dir and results dir.
+
+To override the default configuration location the CLI option `-C` or `--config`
+is provided.
+
+The following is an example configuration file. The ipa section is required
+and the provider sections are optional and can be [EC2] or [Azure].
+
+[source,ini]
+----
+[ipa]
+tests=~/ipa/tests/
+results=~/ipa/results/
+
+[EC2]
+region=us-west-1
+----
+
+=== Azure
+
+*ipa* shares the azurectl configuration file. See the
+link:https://github.com/SUSE/azurectl#configuration-file[azurectl readme] for
+more info on the location and format.
+
+=== EC2
+
+For testing EC2 instances *ipa* will use the ec2utils configuration file
+located at ~/.ec2utils.conf. See
+link:https://github.com/SUSE/Enceladus/tree/master/ec2utils[ec2utils] for an
+example configuration file.
+
+=== Provider Configuration location
+
+To override the provider configuration the CLI option, `--provider-config` is
+available.
+
+== Usage
+
+=== CLI
+
+`ipa test`
+
+Test image in the given framework using the supplied test files.
+
+[source]
+----
+# Testing an image in EC2
+
+> ipa test -i {image-id} -a {account} --provider-config ~/.ec2utils.conf \
+> --no-cleanup -d openSUSE_Leap EC2 test_image
+
+Starting instance
+Running tests /home/{user}/ipa/tests/test_image.py
+PASSED tests=1|pass=1|fail=0|error=0
+
+# Testing an image in Azure
+
+> ipa test -i {image-id} --no-cleanup -d openSUSE_Leap \
+> --ssh-private-key {azure-ssh-key-file} Azure test_image
+
+Starting instance
+Running tests /home/{user}/ipa/tests/test_image.py
+PASSED tests=1|pass=1|fail=0|error=0
+----
+
+==== Verbosity
+
+The CLI output verbosity can be controlled via options:
+
+`--debug`
+
+Display debug level logging to console.
+
+`--verbose`
+
+(Default) Display logging info to console.
+
+`--quiet`
+
+Silence logging information on test run.
+
+==== Cleanup
+
+By default the instance will be terminated if all tests pass. If a test fails
+the instance will remain running. This behavior can be changed with the
+`--cleanup` and `--no-cleanup` flags.
+
+`--cleanup`
+
+Instance will be terminated in all cases.
+
+`--no-cleanup`
+
+Instance will remain running in all cases.
+
+==== ANSI Style
+
+By default the command line output will be colored. To disable color output
+use the `--no-color` option.
+
+==== Early Exit
+
+The early exit option will stop the test run on the first failure.
+`--early-exit` is passed to Pytest as `-x`. See
+link:https://docs.pytest.org/en/latest/usage.html#stopping-after-the-first-or-n-failures[Pytest docs]
+for more info.
+
+=== Code
+
+*ipa* primarily provides a CLI tool for testing images. However, the endpoints
+can be imported directly in Python 3 code through the controller.
+
+[source,python]
+----
+from ipa.ipa_controller import test_image
+
+status, results = test_image(
+    provider,
+    access_key_id,
+    ...
+    storage_container,
+    tests
+)
+----

--- a/docs/tests.asciidoc
+++ b/docs/tests.asciidoc
@@ -1,0 +1,163 @@
+= Writing Tests
+:toc:
+
+Tests are developed using the link:https://testinfra.readthedocs.io[Testinfra]
+package. The package extends Pytest and provides a framework for writing Python
+tests to verify the actual state of systems. The default locations for test
+files are locally in ~/ipa/tests/ and centralized in /usr/share/ipa/tests.
+
+Tests can be organized in a directory structure:
+
+----
+~/ipa/tests/:
+  conftest.py           # Pytest custom modules and config goes here
+  test-image.py         # Generic tests for all images
+  leap-leap-422:
+    test-leap-422.py        # Generic leap tests
+    EC2:
+      test-leap-422-ec2.py  # Specific EC2 tests for leap images
+    GCE:
+    ...
+  SLES12SP1:
+    test-sles-12-sp1.py
+    test-sles-12-sp1-sap.py    # Can import SLES12SP1 tests
+    EC2:
+      test-sles-12-sp1-sap-ec2.py
+    ...
+  SUMA3:
+    ...
+----
+
+A test file can inherit tests by importing another file. For example the
+test-leap-422.py file would import test-image.py to include all generic
+image tests. An example for this structure would be similar to the files
+below:
+
+[source,python]
+.test-leap-422-ec2.py
+----
+import pytest
+from test-leap-422 import *           # Import all generic leap tests
+
+@pytest.mark.parametrize("name", [
+    ("cloud-init"),
+    ("amazon-ssm-agent"),
+])
+def test-services-running-enabled(Service, name):
+    service = Service(name)
+    assert service.is-running
+    assert service.is-enabled
+----
+
+The file which contains specific leap 42.2 tests for EC2 images inherits
+all tests specific to the leap 42.2 image.
+
+[source,python]
+.test-leap-422.py
+----
+import pytest
+from test-image import *          # Import all generic image tests
+
+@pytest.mark.parametrize("repo,name", [
+    ("repo-oss", "openSUSE-Leap-42.1-Oss"),
+    ("repo-non-oss", "openSUSE-Leap-42.1-Non-Oss"),
+])
+def test-repos(CheckRepo, repo, name):
+    assert CheckRepo(repo, name)
+----
+
+The leap 42.2 test file inherits all generic image tests.
+
+[source,python]
+.test-image.py
+----
+import pytest
+
+@pytest.mark.parametrize("name,version", [
+    ("python-virtualenv", "13"),
+    ("python", "2.7"),
+])
+def test-packages(Package, name, version):
+    assert Package(name).is-installed
+    assert Package(name).version.startswith(version)
+
+
+def test-echo(Echo):
+    assert Echo("Hello") == 'Hello'
+----
+
+Thus when invoking the test-leap-422-ec2.py file the following tests are
+run:
+
+----
+$ ipa test test-leap-422-ec2 --ssh-private-key key-file --ssh-user ec2-user
+
+> PASSED tests=7|pass=7|fail=0|error=0
+----
+
+All 7 tests from the three test files are ran when testing the 42.2 EC2
+image.
+
+== Test invocation
+
+To invoke the entire test suite for a Leap image in EC2 the
+test-leap-42.2-ec2.py target would be used.
+
+To invoke a specific test the Pytest conventions can be used:
+
+----
+test-leap-422-ec2::test-services-running-enabled
+----
+
+To run only one parameterized test append ids and use [local-ID]:
+
+[source,python]
+----
+@pytest.mark.parametrize("name", [
+    ("cloud-init"),
+    ("amazon-ssm-agent"),
+], ids=['ci', 'ssm'])
+
+
+test-leap-422-ec2::test-services-running-enabled[local-ssm]
+----
+
+=== Failures
+
+By default all tests will run even with failure. Using the `--early-exit` option
+will halt test invocation at first failure.
+
+link:http://pytest.org/dev/example/simple.html#incremental-testing-test-steps[Incremental test classes]
+can be used to cause all subsequent tests to fail if the prev fails. To prevent
+expected failures.
+
+== Custom Test Modules
+
+Modules are provided for checking standard things such as packages,
+services, files, dirs etc. Modules can be easily written and extended
+from to provide custom modules such as CheckRepo. Any custom modules
+could be written in conftest.py in the same dir and would be resolved by
+Pytest automagically:
+
+[source,python]
+.conftest.py
+----
+import pytest
+
+@pytest.fixture()
+def Echo(Command):
+    def f(arg):
+        return Command.check-output("echo %s", arg)
+    return f
+
+
+@pytest.fixture()
+def CheckRepo(File):
+    def f(repo, name):
+        repo = File('/etc/zypp/repos.d/' + repo + '.repo')
+        tests = [repo.exists,
+                 repo.contains('enabled=1'),
+                 repo.contains('name=%s' % name)]
+        return all(tests)
+    return f
+----

--- a/ipa/__init__.py
+++ b/ipa/__init__.py
@@ -22,4 +22,4 @@
 
 __author__ = """SUSE"""
 __email__ = 'public-cloud-dev@susecloud.net'
-__version__ = '0.1.0'
+__version__ = '0.0.1'

--- a/ipa/scripts/cli.py
+++ b/ipa/scripts/cli.py
@@ -45,7 +45,7 @@ from ipa.scripts.cli_utils import (
 def print_license(ctx, param, value):
     if not value or ctx.resilient_parsing:
         return
-    click.echo('GPL-v3')
+    click.echo('GPLv3+')
     ctx.exit()
 
 


### PR DESCRIPTION
- Add getting started doc with general info for using ipa.
- Add source doc and move overview of source code.
- Add tests doc and move info on writing tests for ipa.
- Fix zypper install command to be python3.
- Fix CLI license message to match setup format.
- Add table of contents to readme and contributing docs.
- Add initial release to changelog.