### PR TITLE
Provider config is optional and can be None.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.5"
   - "3.6"
 install:
-  - pip install tox
-  - pip install tox-pyenv
-  - pip install tox-travis
-script: tox
+  - pip install -e .[dev]
+script:
+  - pytest --cov=ipa
+  - flake8 ipa

--- a/ipa/ipa_provider.py
+++ b/ipa/ipa_provider.py
@@ -108,12 +108,12 @@ class IpaProvider(object):
             default=IPA_HISTORY_FILE
         )
 
-        self.provider_config = os.path.expanduser(
-            self._get_value(
+        self.provider_config = self._get_value(
                 provider_config,
                 config_key='provider_config'
-            )
         )
+        if self.provider_config:
+            self.provider_config = os.path.expanduser(self.provider_config)
 
         self.region = self._get_value(
             region,


### PR DESCRIPTION
- Neglected to run tests with previous commit. :disappointed: 
  - Expanduser raises exception if None thus only expand if str is not (empty or None).
- Update travis config to not use tox. Tox is not needed to test all supported Python versions.