### PR TITLE
Remove autotag from bumpversion config.

### DIFF
--- a/CONTRIBUTING.asciidoc
+++ b/CONTRIBUTING.asciidoc
@@ -50,7 +50,7 @@ git push
 ----
 
 Bumpversion will create a commit with version updated in all locations. The
-annotatated tag is created separately.
+annotated tag is created separately.
 
 ----
 git tag -a v{version}

--- a/CONTRIBUTING.asciidoc
+++ b/CONTRIBUTING.asciidoc
@@ -46,7 +46,19 @@ for release version management, and is configured in `setup.cfg`:
 
 ----
 bumpversion major|minor|patch
-git push && git push --tags
+git push
+----
+
+Bumpversion will create a commit with version updated in all locations. The
+annotatated tag is created separately.
+
+----
+git tag -a v{version}
+# git tag -a v0.0.1
+
+# Create a message with the changes since last release and push tags.
+
+git push --tags
 ----
 
 == Unit & Integration Tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 0.0.1
 commit = True
-tag = True
+tag = False
 
 [bumpversion:file:setup.py]
 


### PR DESCRIPTION
- Bumpversion does not create annotated tags so disable tagging.
- Update docs with steps to create annotated tag with new version.