### PR TITLE
Code cleanup

### DIFF
--- a/ipa-complete.sh
+++ b/ipa-complete.sh
@@ -1,2 +1,2 @@
+#! /bin/sh -
 _IPA_COMPLETE=source ipa
-

--- a/ipa/collect_items.py
+++ b/ipa/collect_items.py
@@ -43,7 +43,7 @@ class CollectItemsPlugin(object):
             test_class = None
             try:
                 path, test_class, parens, test_case = item.nodeid.split('::')
-            except:
+            except ValueError:
                 path, test_case = item.nodeid.split('::')
 
             test_file = path.split(os.sep)[-1].replace('.py', '')

--- a/ipa/ipa_provider.py
+++ b/ipa/ipa_provider.py
@@ -28,6 +28,7 @@ import shlex
 
 import pytest
 
+from collections import defaultdict
 from datetime import datetime
 
 from ipa import ipa_utils
@@ -122,7 +123,10 @@ class IpaProvider(object):
 
         self.results = {
             "tests": [],
-            "summary": {"duration": 0, "passed": 0, "num_tests": 0}
+            "summary": defaultdict(
+                int,
+                {"duration": 0, "passed": 0, "num_tests": 0}
+            )
         }
 
         self.results_dir = os.path.expanduser(
@@ -210,10 +214,7 @@ class IpaProvider(object):
         self.results['tests'] += results['tests']
 
         for key, value in results['summary'].items():
-            if key in self.results['summary']:
-                self.results['summary'][key] += results['summary'][key]
-            else:
-                self.results['summary'][key] = results['summary'][key]
+            self.results['summary'][key] += value
 
     def _parse_test_files(self, test_dirs):
         """

--- a/ipa/ipa_utils.py
+++ b/ipa/ipa_utils.py
@@ -352,7 +352,7 @@ def get_yaml_config(config_path):
         )
 
     with open(config_path, 'r') as f:
-        config = yaml.load(f)
+        config = yaml.safe_load(f)
     return config
 
 

--- a/ipa/results_plugin.py
+++ b/ipa/results_plugin.py
@@ -33,7 +33,7 @@ class Report(object):
     def __init__(self):
         """Initialize results plugin."""
         self.tests = defaultdict(dict)
-        self.summary = defaultdict(lambda: 0)
+        self.summary = defaultdict(int)
         self.test_index = 0
         self.report = {}
 

--- a/ipa/scripts/cli.py
+++ b/ipa/scripts/cli.py
@@ -342,7 +342,7 @@ def results(clear,
                     fg='red'
                 )
                 sys.exit(1)
-            except Exception as error:
+            except Exception:
                 echo_style(
                     'Unable to retrieve results history, '
                     'provide results file or re-run test.',

--- a/ipa/scripts/cli.py
+++ b/ipa/scripts/cli.py
@@ -354,7 +354,7 @@ def results(clear,
             try:
                 # Desc is optional
                 log_file, desc = shlex.split(history)
-            except:
+            except ValueError:
                 log_file = history.strip()
 
             if log:

--- a/ipa/scripts/cli_utils.py
+++ b/ipa/scripts/cli_utils.py
@@ -133,7 +133,7 @@ def results_history(history_log, no_color):
             lines = f.readlines()
     except Exception as error:
         echo_style(
-            'Unable to process results history log.',
+            'Unable to process results history log: %s' % error,
             no_color,
             fg='red'
         )


### PR DESCRIPTION
- Use defaultdict with default values to simplify merge_results in ipa_provider.
- Cleanup unused error messages.
- Add shebang to autocomplete script.
- Specify except ValueError where optional args omitted in tuple unpacking.
- Use yaml safe_load instead of load.
- Use int callable in results_plugin defaultdict, which has default of 0, instead of lamba function.