### PR TITLE
Test result names

### DIFF
--- a/ipa/__init__.py
+++ b/ipa/__init__.py
@@ -22,4 +22,4 @@
 
 __author__ = """SUSE"""
 __email__ = 'public-cloud-dev@susecloud.net'
-__version__ = '0.0.2'
+__version__ = '0.0.4'

--- a/ipa/ipa_utils.py
+++ b/ipa/ipa_utils.py
@@ -397,6 +397,18 @@ def parse_sync_points(names, tests):
     return test_files
 
 
+def parse_test_name(name):
+    """Parse and return formatted pytest test name string."""
+    test_class = None
+    try:
+        path, test_class, parens, test_case = name.split('::')
+    except ValueError:
+        path, test_case = name.split('::')
+
+    test_file = path.split(os.sep)[-1].replace('.py', '')
+    return '::'.join(filter(None, [test_file, test_class, test_case]))
+
+
 @contextmanager
 def redirect_output(fileobj):
     """Redirect standard out to file."""

--- a/ipa/scripts/cli_utils.py
+++ b/ipa/scripts/cli_utils.py
@@ -20,12 +20,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import sys
 
 import click
 
 from ipa.ipa_controller import collect_results
+from ipa.ipa_utils import parse_test_name
 
 
 def echo_log(log_file, no_color):
@@ -118,7 +118,7 @@ def echo_verbose_results(data, no_color):
         else:
             fg = 'red'
 
-        name = test['name'].split(os.sep)[-1].replace('.py', '')
+        name = parse_test_name(test['name'])
         echo_style(
             '{} {}'.format(name, test['outcome'].upper()),
             no_color,

--- a/package/python-ipa.spec
+++ b/package/python-ipa.spec
@@ -19,7 +19,7 @@
 %define skip_python2 1
 %bcond_without test
 Name:           python-ipa
-Version:        0.0.2
+Version:        0.0.4
 Release:        0
 Summary:        Command line and API for testing custom images
 License:        GPL-3.0+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.2
+current_version = 0.0.4
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ dev_requirements = [
 
 setup(
     name='ipa',
-    version='0.0.2',
+    version='0.0.4',
     description="Package for automated testing of cloud images.",
     long_description=readme,
     author="SUSE",


### PR DESCRIPTION
Add parse test name static method to account for test classes and parameterized tests.