### PR TITLE
Check host key after reboot.

### DIFF
--- a/CHANGES.asciidoc
+++ b/CHANGES.asciidoc
@@ -1,5 +1,9 @@
 = Changelog
 
+== v0.1.2 (2017-08-31)
+
+- After soft and hard reboot ensure host key has not changed.
+
 == v0.1.1 (2017-08-30)
 
 - Python3 format spec instead of Python single spec.

--- a/ipa/__init__.py
+++ b/ipa/__init__.py
@@ -22,4 +22,4 @@
 
 __author__ = """SUSE"""
 __email__ = 'public-cloud-dev@susecloud.net'
-__version__ = '0.1.1'
+__version__ = '0.1.2'

--- a/ipa/ipa_utils.py
+++ b/ipa/ipa_utils.py
@@ -30,6 +30,7 @@ import time
 import paramiko
 import yaml
 
+from binascii import hexlify
 from contextlib import contextmanager
 from string import ascii_lowercase
 from tempfile import NamedTemporaryFile
@@ -67,7 +68,6 @@ def establish_ssh_connection(ip,
     """
     client = paramiko.SSHClient()
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    client.load_system_host_keys()
 
     while attempts:
         try:
@@ -235,6 +235,13 @@ def get_from_config(config, section, default_section, entry):
                 'Unable to get %s value from config.' % entry
             )
     return value
+
+
+def get_host_key_fingerprint(client):
+    """Get host key fingerprint of SSH client."""
+    return hexlify(
+        client.get_transport().get_remote_server_key().get_fingerprint()
+    )
 
 
 def get_random_string(length=12):

--- a/package/python-ipa.spec
+++ b/package/python-ipa.spec
@@ -17,7 +17,7 @@
 
 %bcond_without test
 Name:           python3-ipa
-Version:        0.1.1
+Version:        0.1.2
 Release:        0
 Summary:        Command line and API for testing custom images
 License:        GPL-3.0+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.1.2
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ dev_requirements = [
 
 setup(
     name='ipa',
-    version='0.1.1',
+    version='0.1.2',
     description="Package for automated testing of cloud images.",
     long_description=readme,
     author="SUSE",

--- a/tests/azure/test_azure.py
+++ b/tests/azure/test_azure.py
@@ -40,9 +40,11 @@ from unittest.mock import patch
 @patch('ipa.ipa_utils.generate_instance_name')
 @patch.object(IpaProvider, '_run_tests')
 @patch.object(IpaProvider, '_get_ssh_client')
+@patch('ipa.ipa_utils.get_host_key_fingerprint')
 @patch.object(time, 'sleep')
 @vcr.use_cassette()
 def test_azure_provider(mock_sleep,
+                        mock_get_host_key,
                         mock_get_ssh_client,
                         mock_run_tests,
                         mock_generate_inst_name,
@@ -51,6 +53,7 @@ def test_azure_provider(mock_sleep,
     """Test Azure Provider with a new instance."""
     # Mock SSH connection attempts
     mock_sleep.return_value = None
+    mock_get_host_key.return_value = b'04820482'
     mock_get_ssh_client.return_value = None
     mock_run_tests.return_value = 0
 

--- a/tests/ec2/test_ec2.py
+++ b/tests/ec2/test_ec2.py
@@ -37,9 +37,14 @@ boto3 = pytest.importorskip("boto3")
 @patch.object(time, 'sleep')
 @patch.object(IpaProvider, '_run_tests')
 @patch.object(IpaProvider, '_get_ssh_client')
+@patch('ipa.ipa_utils.get_host_key_fingerprint')
 @vcr.use_cassette()
-def test_ec2_provider(mock_get_ssh_client, mock_run_tests, mock_sleep):
+def test_ec2_provider(mock_get_host_key,
+                      mock_get_ssh_client,
+                      mock_run_tests,
+                      mock_sleep):
     """Test EC2 Provider with new instance."""
+    mock_get_host_key.return_value = b'04820482'
     mock_get_ssh_client.return_value = None
     mock_run_tests.return_value = 0
     mock_sleep.return_value = None

--- a/tests/test_ipa_provider.py
+++ b/tests/test_ipa_provider.py
@@ -264,15 +264,18 @@ class TestIpaProvider(object):
     @patch.object(IpaProvider, '_set_image_id')
     @patch.object(IpaProvider, '_start_instance_if_stopped')
     @patch.object(IpaProvider, '_get_ssh_client')
+    @patch('ipa.ipa_utils.get_host_key_fingerprint')
     @patch.object(IpaProvider, 'hard_reboot_instance')
     def test_provider_bad_connect_hard_reboot(self,
                                               mock_hard_reboot,
+                                              mock_get_host_key,
                                               mock_get_ssh_client,
                                               mock_start_instance,
                                               mock_set_image_id,
                                               mock_set_instance_ip):
         """Test exception when connection not established after hard reboot."""
         mock_hard_reboot.return_value = None
+        mock_get_host_key.return_value = b'04820482'
         mock_get_ssh_client.side_effect = [None, IpaSSHException('ERROR!')]
         mock_start_instance.return_value = None
         mock_set_image_id.return_value = None
@@ -307,15 +310,18 @@ class TestIpaProvider(object):
     @patch.object(IpaProvider, '_set_image_id')
     @patch.object(IpaProvider, '_start_instance_if_stopped')
     @patch.object(IpaProvider, '_get_ssh_client')
+    @patch('ipa.ipa_utils.get_host_key_fingerprint')
     @patch.object(Distro, 'reboot')
     def test_provider_bad_connect_soft_reboot(self,
                                               mock_soft_reboot,
+                                              mock_get_host_key,
                                               mock_get_ssh_client,
                                               mock_start_instance,
                                               mock_set_image_id,
                                               mock_set_instance_ip):
         """Test exception when connection not established after hard reboot."""
         mock_soft_reboot.return_value = None
+        mock_get_host_key.return_value = b'04820482'
         mock_get_ssh_client.side_effect = [
             None,
             None,
@@ -354,15 +360,18 @@ class TestIpaProvider(object):
     @patch.object(IpaProvider, '_set_image_id')
     @patch.object(IpaProvider, '_start_instance_if_stopped')
     @patch.object(IpaProvider, '_get_ssh_client')
+    @patch('ipa.ipa_utils.get_host_key_fingerprint')
     @patch.object(IpaProvider, '_run_tests')
     def test_provider_break_if_test_failure(self,
                                             mock_run_tests,
+                                            mock_get_host_key,
                                             mock_get_ssh_client,
                                             mock_start_instance,
                                             mock_set_image_id,
                                             mock_set_instance_ip):
         """Test exception raised when invalid test item provided."""
         mock_run_tests.return_value = 1
+        mock_get_host_key.return_value = b'04820482'
         mock_get_ssh_client.return_value = None
         mock_start_instance.return_value = None
         mock_set_image_id.return_value = None

--- a/tests/test_ipa_utils.py
+++ b/tests/test_ipa_utils.py
@@ -242,6 +242,19 @@ def test_utils_get_from_config():
     assert val == 'us-west-1'
 
 
+def test_utils_get_host_key_fingerprint():
+    """Test get host key fingerprint function."""
+    client = MagicMock()
+    transport = MagicMock()
+    key = MagicMock()
+
+    client.get_transport.return_value = transport
+    transport.get_remote_server_key.return_value = key
+    key.get_fingerprint.return_value = b'\x04\x82\x04\x82'
+
+    assert ipa_utils.get_host_key_fingerprint(client) == b'04820482'
+
+
 def test_utils_get_random_string():
     """Test get random string function returns default len 12 string."""
     rand_string = ipa_utils.get_random_string()


### PR DESCRIPTION
After soft and hard reboot ensure host key has not changed.

Note: Instead of a separate test I thought this would be more useful. Checking the host key after every reboot and after a new client connection is established.