### PR TITLE
Fix bug if test fails before sync point.

### DIFF
--- a/ipa/ipa_provider.py
+++ b/ipa/ipa_provider.py
@@ -475,8 +475,9 @@ class IpaProvider(object):
                     with open(self.log_file, 'a') as log_file:
                         with ipa_utils.redirect_output(log_file):
                             # Run tests
-                            status = (status or
-                                      self._run_tests(item, ssh_config))
+                            result = self._run_tests(item, ssh_config)
+                            status = status or result
+
                 else:
                     raise IpaProviderException(
                         'Invalid test item in list: %s' % item


### PR DESCRIPTION
If test failed before sync point any subsequent tests would not be run. Get result of subsequent tests and calculate status separately.

Fixes #32 