### PR TITLE
EC2 Cleanup

### DIFF
--- a/ipa/ipa_ec2.py
+++ b/ipa/ipa_ec2.py
@@ -146,6 +146,7 @@ class EC2Provider(LibcloudProvider):
         )
 
     def _get_image(self):
+        """Retrieve NodeImage given the image id."""
         try:
             image = self.compute_driver.list_images(
                 ex_image_ids=[self.image_id]
@@ -174,6 +175,7 @@ class EC2Provider(LibcloudProvider):
         return instance
 
     def _get_instance_size(self):
+        """Retrieve NodeSize given the instance type."""
         instance_type = self.instance_type or EC2_DEFAULT_TYPE
 
         try:

--- a/ipa/ipa_ec2.py
+++ b/ipa/ipa_ec2.py
@@ -162,10 +162,9 @@ class EC2Provider(LibcloudProvider):
     def _get_instance(self):
         """Retrieve instance matching instance_id."""
         try:
-            instances = self.compute_driver.list_nodes(
+            instance = self.compute_driver.list_nodes(
                 ex_node_ids=[self.running_instance_id]
-            )
-            instance = instances[0]
+            )[0]
         except (IndexError, BaseHTTPError):
             raise EC2ProviderException(
                 'Instance with ID: {instance_id} not found.'.format(


### PR DESCRIPTION
- Split out get_image and get_instance_size to separate methods.
- Simplify get_instance, list of instances is never used.