### PR TITLE
Use cpe_name to determine sap product.

### DIFF
--- a/usr/share/lib/ipa/tests/SLES/infra/test_sles_force_new_smt_reg.py
+++ b/usr/share/lib/ipa/tests/SLES/infra/test_sles_force_new_smt_reg.py
@@ -4,7 +4,6 @@ from distutils.version import StrictVersion
 
 
 def test_sles_force_new_smt_reg(check_cloud_register,
-                                get_release_value,
                                 get_smt_servers,
                                 host,
                                 request):
@@ -28,8 +27,7 @@ def test_sles_force_new_smt_reg(check_cloud_register,
     )
     fingerprint = result.stdout.split('=')[-1]
 
-    pretty_name = get_release_value('PRETTY_NAME')
-    servers = get_smt_servers(pretty_name, provider, region)
+    servers = get_smt_servers(provider, region)
 
     result = host.run(
         'sudo registercloudguest --force-new --smt-ip={ip} '

--- a/usr/share/lib/ipa/tests/SLES/infra/test_sles_switch_smt.py
+++ b/usr/share/lib/ipa/tests/SLES/infra/test_sles_switch_smt.py
@@ -3,7 +3,6 @@ import shlex
 
 def test_sles_switch_smt(get_smt_server_name,
                          get_smt_servers,
-                         get_release_value,
                          host,
                          request):
     """
@@ -19,8 +18,7 @@ def test_sles_switch_smt(get_smt_server_name,
     )
     smt_ip = shlex.split(result.stdout)[0]
 
-    pretty_name = get_release_value('PRETTY_NAME')
-    servers = get_smt_servers(pretty_name, provider, region)
+    servers = get_smt_servers(provider, region)
 
     for server in servers:
         if server['ip'] != smt_ip:

--- a/usr/share/lib/ipa/tests/SLES/test_sles_smt_reg.py
+++ b/usr/share/lib/ipa/tests/SLES/test_sles_smt_reg.py
@@ -2,7 +2,6 @@ import shlex
 
 
 def test_sles_smt_reg(check_cloud_register,
-                      get_release_value,
                       get_smt_server_name,
                       get_smt_servers,
                       host,
@@ -12,8 +11,7 @@ def test_sles_smt_reg(check_cloud_register,
 
     assert check_cloud_register()
 
-    pretty_name = get_release_value('PRETTY_NAME')
-    servers = get_smt_servers(pretty_name, provider, region)
+    servers = get_smt_servers(provider, region)
     smt_ips = [server['ip'] for server in servers]
 
     result = host.run(

--- a/usr/share/lib/ipa/tests/conftest.py
+++ b/usr/share/lib/ipa/tests/conftest.py
@@ -68,9 +68,10 @@ def get_smt_server_name(host):
 
 
 @pytest.fixture()
-def get_smt_servers(host):
-    def f(pretty_name, provider, region):
-        if 'SAP' in pretty_name:
+def get_smt_servers(get_release_value, host):
+    def f(provider, region):
+        cpe_name = get_release_value('CPE_NAME')
+        if 'sap' in cpe_name:
             smt_type = 'smt-sap'
         else:
             smt_type = 'smt-sles'


### PR DESCRIPTION
Simplify get_smt_servers fixture. Get release value inside fixture instead of requiring cpe_name as arg.

Fixes #49 