### PR TITLE
Allow EC2 testing without config file.

### DIFF
--- a/ipa/ipa_ec2.py
+++ b/ipa/ipa_ec2.py
@@ -83,7 +83,7 @@ class EC2Provider(LibcloudProvider):
         self.account_name = account_name
 
         if not self.account_name:
-            self.logger.warning(
+            self.logger.debug(
                 'No account provided. To use the EC2 config file an '
                 'account name is required.'
             )

--- a/ipa/ipa_ec2.py
+++ b/ipa/ipa_ec2.py
@@ -26,7 +26,7 @@ from ipa.ipa_constants import (
     EC2_DEFAULT_TYPE,
     EC2_DEFAULT_USER
 )
-from ipa.ipa_exceptions import EC2ProviderException
+from ipa.ipa_exceptions import IpaException, EC2ProviderException
 from ipa.ipa_libcloud import LibcloudProvider
 
 from libcloud.common.exceptions import BaseHTTPError
@@ -80,23 +80,31 @@ class EC2Provider(LibcloudProvider):
                                           running_instance_id,
                                           test_dirs,
                                           test_files)
-        config_file = self.provider_config or EC2_CONFIG_FILE
+        self.account_name = account_name
 
-        if not account_name:
-            raise EC2ProviderException(
-                'Account required for config file: %s' % config_file
+        if not self.account_name:
+            self.logger.warning(
+                'No account provided. To use the EC2 config file an '
+                'account name is required.'
             )
+
+        config_file = self.provider_config or EC2_CONFIG_FILE
 
         if not self.region:
             raise EC2ProviderException(
                 'Region is required to connect to EC2.'
             )
 
-        self.account_name = account_name
-        self.ec2_config = ipa_utils.get_config(config_file)
-        self.logger.debug(
-            'Using EC2 config file: %s' % config_file
-        )
+        try:
+            self.ec2_config = ipa_utils.get_config(config_file)
+            self.logger.debug(
+                'Using EC2 config file: %s' % config_file
+            )
+        except IpaException:
+            self.ec2_config = None
+            self.logger.debug(
+                'EC2 config file not found: %s' % config_file
+            )
 
         self.access_key_id = (
             access_key_id or
@@ -129,6 +137,16 @@ class EC2Provider(LibcloudProvider):
 
     def _get_driver(self):
         """Get authenticated EC2 driver."""
+        if not self.access_key_id:
+            raise EC2ProviderException(
+                'Access key id is required to authenticate EC2 driver.'
+            )
+
+        if not self.secret_access_key:
+            raise EC2ProviderException(
+                'Secret access key is required to authenticate EC2 driver.'
+            )
+
         ComputeEngine = get_driver(Provider.EC2)
         return ComputeEngine(
             self.access_key_id,
@@ -138,12 +156,15 @@ class EC2Provider(LibcloudProvider):
 
     def _get_from_ec2_config(self, entry):
         """Get config entry from ec2utils config file."""
-        return ipa_utils.get_from_config(
-            self.ec2_config,
-            ''.join(['region-', self.region]),
-            ''.join(['account-', self.account_name]),
-            entry
-        )
+        if self.ec2_config and self.account_name:
+            return ipa_utils.get_from_config(
+                self.ec2_config,
+                ''.join(['region-', self.region]),
+                ''.join(['account-', self.account_name]),
+                entry
+            )
+        else:
+            return None
 
     def _get_image(self):
         """Retrieve NodeImage given the image id."""

--- a/tests/test_ipa_ec2.py
+++ b/tests/test_ipa_ec2.py
@@ -46,18 +46,7 @@ class TestEC2Provider(object):
 
     def test_ec2_exception_required_args(self):
         """Test an exception is raised if required args missing."""
-        self.kwargs['account_name'] = None
-        msg = 'Account required for config file: %s' \
-            % self.kwargs['provider_config']
-
-        # Test account required
-        with pytest.raises(EC2ProviderException) as error:
-            EC2Provider(**self.kwargs)
-
-        assert str(error.value) == msg
-
         self.kwargs['config'] = 'tests/data/config.noregion'
-        self.kwargs['account_name'] = 'bob'
         msg = 'Region is required to connect to EC2.'
 
         # Test region required


### PR DESCRIPTION
If all args are provided via command line testing is possible without the EC2 config file.

Chose to log a warning level message if account is not provided. Hopefully, to alleviate confusion with regards to use of config file.

Closes #52 