### PR TITLE
Change tests list to be optional.

### DIFF
--- a/ipa/ipa_provider.py
+++ b/ipa/ipa_provider.py
@@ -150,9 +150,6 @@ class IpaProvider(object):
                 'Image ID or running instance is required.'
             )
 
-        if not self.test_files:
-            raise IpaProviderException('No test files found.')
-
         self._parse_test_files(test_dirs, no_default_test_dirs)
 
     def _get_instance(self):

--- a/tests/test_ipa_provider.py
+++ b/tests/test_ipa_provider.py
@@ -94,18 +94,6 @@ class TestIpaProvider(object):
         assert str(error.value) == \
             'Image ID or running instance is required.'
 
-    def test_provider_tests_required(self):
-        """Test exception raised if no tests provided."""
-        with pytest.raises(IpaProviderException) as error:
-            IpaProvider(
-                *args,
-                config='tests/data/config',
-                distro_name='SLES',
-                image_id='test'
-            )
-
-        assert str(error.value) == 'No test files found.'
-
     @patch.object(ipa_utils, 'get_ssh_client')
     def test_provider_get_ssh_client(self, mock_get_ssh_client):
         """Test get ssh client method."""


### PR DESCRIPTION
This can be used with --no-cleanup option to start an instance.
Or to cleanup an existing instance after testing.