### PR TITLE
Add regresion test for EC2 to check uuid.

### DIFF
--- a/usr/share/lib/ipa/tests/SLES/EC2/test_sles_ec2.yaml
+++ b/usr/share/lib/ipa/tests/SLES/EC2/test_sles_ec2.yaml
@@ -1,2 +1,3 @@
 tests:
   - test_sles_ec2_services
+  - test_sles_ec2_uuid

--- a/usr/share/lib/ipa/tests/SLES/EC2/test_sles_ec2_uuid.py
+++ b/usr/share/lib/ipa/tests/SLES/EC2/test_sles_ec2_uuid.py
@@ -1,0 +1,5 @@
+
+
+def test_sles_ec2_uuid(host):
+    result = host.run('sudo cat /sys/devices/virtual/dmi/id/product_uuid')
+    assert result.stdout.startswith('EC2')


### PR DESCRIPTION
product_uuid for instance in EC2 should start with EC2.