### PR TITLE
Add regresion test to confirm lscpu.

### DIFF
--- a/usr/share/lib/ipa/tests/SLES/test_sles.yaml
+++ b/usr/share/lib/ipa/tests/SLES/test_sles.yaml
@@ -5,3 +5,4 @@ tests:
   - test_hard_reboot
   - test_sles_hostname
   - test_sles_haveged
+  - test_sles_lscpu

--- a/usr/share/lib/ipa/tests/SLES/test_sles_lscpu.py
+++ b/usr/share/lib/ipa/tests/SLES/test_sles_lscpu.py
@@ -1,0 +1,5 @@
+
+
+def test_sles_lscpu(host):
+    result = host.run('lscpu')
+    assert result.rc == 0


### PR DESCRIPTION
Confirm lscpu binary returns successful exit code.