### PR TITLE
Add subnet option for GCE and EC2.

### DIFF
--- a/ipa/ipa_azure.py
+++ b/ipa/ipa_azure.py
@@ -60,6 +60,7 @@ class AzureProvider(IpaProvider):
                  ssh_private_key=None,
                  ssh_user=None,
                  storage_container=None,
+                 subnet_id=None,  # Not used in Azure
                  test_dirs=None,
                  test_files=None):
         """Initialize Azure Provider class."""

--- a/ipa/ipa_controller.py
+++ b/ipa/ipa_controller.py
@@ -54,6 +54,7 @@ def test_image(provider_name,
                ssh_private_key=None,
                ssh_user=None,
                storage_container=None,
+               subnet_id=None,
                test_dirs=None,
                tests=None):
     """Creates a cloud provider instance and initiates testing."""
@@ -86,6 +87,7 @@ def test_image(provider_name,
             ssh_private_key=ssh_private_key,
             ssh_user=ssh_user,
             storage_container=storage_container,
+            subnet_id=subnet_id,
             test_dirs=test_dirs,
             test_files=tests
         )

--- a/ipa/ipa_libcloud.py
+++ b/ipa/ipa_libcloud.py
@@ -40,9 +40,11 @@ class LibcloudProvider(IpaProvider):
         """Retrieve and set the instance ip address."""
         instance = self._get_instance()
 
-        try:
+        if instance.public_ips:
             self.instance_ip = instance.public_ips[0]
-        except IndexError:
+        elif instance.private_ips:
+            self.instance_ip = instance.private_ips[0]
+        else:
             raise LibcloudProviderException(
                 'IP address for instance: %s cannot be found.'
                 % self.running_instance_id

--- a/ipa/scripts/cli.py
+++ b/ipa/scripts/cli.py
@@ -198,6 +198,10 @@ def main():
     help='Azure storage container to use.'
 )
 @click.option(
+    '--subnet-id',
+    help='Subnet to place the new instance in when launched.'
+)
+@click.option(
     '--test-dirs',
     help='Directories to search for tests.'
 )
@@ -229,6 +233,7 @@ def test(access_key_id,
          ssh_private_key,
          ssh_user,
          storage_container,
+         subnet_id,
          test_dirs,
          provider,
          tests):
@@ -258,6 +263,7 @@ def test(access_key_id,
             ssh_private_key,
             ssh_user,
             storage_container,
+            subnet_id,
             test_dirs,
             tests
         )

--- a/ipa/scripts/cli.py
+++ b/ipa/scripts/cli.py
@@ -199,7 +199,7 @@ def main():
 )
 @click.option(
     '--subnet-id',
-    help='Subnet to place the new instance in when launched.'
+    help='Subnet to launch the new instance into.'
 )
 @click.option(
     '--test-dirs',

--- a/man/man1/ipa-list.1
+++ b/man/man1/ipa-list.1
@@ -1,4 +1,4 @@
-.TH "IPA LIST" "1" "20-Sep-2017" "" "ipa list Manual"
+.TH "IPA LIST" "1" "24-Jan-2018" "" "ipa list Manual"
 .SH NAME
 ipa\-list \- Print a list of test files or test cases.
 .SH SYNOPSIS

--- a/man/man1/ipa-results.1
+++ b/man/man1/ipa-results.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS" "1" "20-Sep-2017" "" "ipa results Manual"
+.TH "IPA RESULTS" "1" "24-Jan-2018" "" "ipa results Manual"
 .SH NAME
 ipa\-results \- Print test results info from provided results...
 .SH SYNOPSIS

--- a/man/man1/ipa-test.1
+++ b/man/man1/ipa-test.1
@@ -1,4 +1,4 @@
-.TH "IPA TEST" "1" "20-Sep-2017" "" "ipa test Manual"
+.TH "IPA TEST" "1" "24-Jan-2018" "" "ipa test Manual"
 .SH NAME
 ipa\-test \- Test image in the given framework using the...
 .SH SYNOPSIS
@@ -82,6 +82,9 @@ SSH user for accessing instance.
 .TP
 \fB\-S,\fP \-\-storage\-container TEXT
 Azure storage container to use.
+.TP
+\fB\-\-subnet\-id\fP TEXT
+Subnet to launch the new instance into.
 .TP
 \fB\-\-test\-dirs\fP TEXT
 Directories to search for tests.

--- a/man/man1/ipa.1
+++ b/man/man1/ipa.1
@@ -1,4 +1,4 @@
-.TH "IPA" "1" "20-Sep-2017" "" "ipa Manual"
+.TH "IPA" "1" "24-Jan-2018" "" "ipa Manual"
 .SH NAME
 ipa \- Ipa provides a Python API and command line...
 .SH SYNOPSIS

--- a/tests/test_ipa_libcloud.py
+++ b/tests/test_ipa_libcloud.py
@@ -82,6 +82,7 @@ class TestLibcloudProvider(object):
         """Test libcloud provider set instance ip method."""
         instance = MagicMock()
         instance.public_ips = []
+        instance.private_ips = []
 
         mock_get_instance.return_value = instance
 


### PR DESCRIPTION
- A subnet-id arg can be provided to launch a new instance in the given network/subnet.
- Attempt to retrieve private IP for instances without public IP.
- Update man pages for new subnet-id option.