### PR TITLE
Testinfra host no longer has system info module.

### DIFF
--- a/usr/share/lib/ipa/tests/SLES/test_sles_hostname.py
+++ b/usr/share/lib/ipa/tests/SLES/test_sles_hostname.py
@@ -1,2 +1,3 @@
 def test_sles_hostname(host):
-    assert host.system_info.hostname != 'linux'
+    result = host.run('hostname')
+    assert result.stdout.strip() != 'linux'


### PR DESCRIPTION
Use run module with hostname command to check hostname.