### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/CHANGES.asciidoc
+++ b/CHANGES.asciidoc
@@ -1,5 +1,17 @@
 = Changelog
 
+== v0.6.0 (2018-02-27)
+
+- Add .pytest_cache to gitignore.
+- Make provider and distro names all lowercase.
+  + Remove need to magically load modules based on name format.
+- Add option to launch instance into existing subnet on GCE
+  and EC2.
+- Add regression test for EC2 UUID.
+- Add regression test for lscpu.
+- Update hostname test, system_info module no longer exists in
+  testinfra.
+
 == v0.5.1 (2017-12-11)
 
 - Cleanup MANIFEST.

--- a/ipa/__init__.py
+++ b/ipa/__init__.py
@@ -22,4 +22,4 @@
 
 __author__ = """SUSE"""
 __email__ = 'public-cloud-dev@susecloud.net'
-__version__ = '0.5.1'
+__version__ = '0.6.0'

--- a/package/python3-ipa.spec
+++ b/package/python3-ipa.spec
@@ -17,7 +17,7 @@
 
 %bcond_without test
 Name:           python3-ipa
-Version:        0.5.1
+Version:        0.6.0
 Release:        0
 Summary:        Command line and API for testing custom images
 License:        GPL-3.0+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.1
+current_version = 0.6.0
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ dev_requirements = [
 
 setup(
     name='python3-ipa',
-    version='0.5.1',
+    version='0.6.0',
     description="Package for automated testing of cloud images.",
     long_description=readme,
     author="SUSE",


### PR DESCRIPTION
Depends on #64 merge. To prevent non-backwards compatible API change.