### PR TITLE
Add put_file utility method.

### DIFF
--- a/ipa/ipa_provider.py
+++ b/ipa/ipa_provider.py
@@ -399,6 +399,22 @@ class IpaProvider(object):
         self.logger.debug('IP of instance: %s' % self.instance_ip)
         ipa_utils.clear_cache()
 
+    def put_file(self, client, source_file):
+        """
+        Put file on instance in default SSH directory.
+        """
+        try:
+            file_name = os.path.basename(source_file)
+            ipa_utils.put_file(client, source_file, file_name)
+        except Exception as error:
+            raise IpaProviderException(
+                'Failed copying file, "{0}"; {1}.'.format(
+                    source_file, error
+                )
+            )
+        else:
+            return file_name
+
     def test_image(self):
         """
         The entry point for testing an image.

--- a/ipa/ipa_utils.py
+++ b/ipa/ipa_utils.py
@@ -457,6 +457,22 @@ def parse_test_name(name):
     return '::'.join(filter(None, [test_file, test_class, test_case]))
 
 
+def put_file(client, source_file, destination_file):
+    """
+    Copy file to instance using Paramiko client connection.
+    """
+    try:
+        sftp_client = client.open_sftp()
+        sftp_client.put(source_file, destination_file)
+    except Exception as error:
+        raise IpaUtilsException(
+            'Error copying file to instance: {0}.'.format(error)
+        )
+    finally:
+        with ignored(Exception):
+            sftp_client.close()
+
+
 @contextmanager
 def redirect_output(fileobj):
     """Redirect standard out to file."""

--- a/tests/test_ipa_provider.py
+++ b/tests/test_ipa_provider.py
@@ -242,6 +242,22 @@ class TestIpaProvider(object):
         assert mock_start_instance.call_count == 1
         assert mock_set_instance_ip.call_count == 1
 
+    @patch('ipa.ipa_utils.put_file')
+    def test_provider_put_file(self, mock_put_file):
+        client = MagicMock()
+
+        file_path = '/home/user/test.file'
+        basename = 'test.file'
+
+        provider = IpaProvider(*args, **self.kwargs)
+        out = provider.put_file(client, file_path)
+
+        assert out == basename
+
+        mock_put_file.assert_called_once_with(
+            client, file_path, basename
+        )
+
     @patch.object(IpaProvider, '_set_instance_ip')
     @patch.object(IpaProvider, '_set_image_id')
     @patch.object(IpaProvider, '_start_instance_if_stopped')

--- a/tests/test_ipa_provider.py
+++ b/tests/test_ipa_provider.py
@@ -224,7 +224,7 @@ class TestIpaProvider(object):
         assert mock_start_instance.call_count == 1
 
     @patch('ipa.ipa_utils.execute_ssh_command')
-    def test_provider_install_package(self, mock_exec_cmd):
+    def test_provider_execute_ssh_command(self, mock_exec_cmd):
         client = MagicMock()
         mock_exec_cmd.return_value = 'command executed successfully!'
 

--- a/tests/test_ipa_utils.py
+++ b/tests/test_ipa_utils.py
@@ -262,6 +262,20 @@ def test_utils_get_random_string():
     assert isinstance(rand_string, str)
 
 
+def test_utils_put_file():
+    client = MagicMock()
+    sftp_client = MagicMock()
+    client.open_sftp.return_value = sftp_client
+
+    source_file = '/home/user/temp.file'
+    destination_file = 'temp.file'
+
+    ipa_utils.put_file(client, source_file, destination_file)
+
+    sftp_client.put.assert_called_once_with(source_file, destination_file)
+    sftp_client.close.assert_called_once_with()
+
+
 def test_utils_redirect_output():
     """Test redirect output context manager."""
     temp_file = NamedTemporaryFile(mode='w+', delete=False)


### PR DESCRIPTION
Uses an existing parmiko client to open an sftp connection and copy the file to the default SSH directory.