### PR TITLE
Explicitly close SSH clients.

### DIFF
--- a/ipa/ipa_utils.py
+++ b/ipa/ipa_utils.py
@@ -47,9 +47,14 @@ CLIENT_CACHE = {}
 def clear_cache(ip=None):
     """Clear the client cache or remove key matching the given ip."""
     if ip:
-        with ignored(KeyError):
+        with ignored(Exception):
+            client = CLIENT_CACHE[ip]
             del CLIENT_CACHE[ip]
+            client.close()
     else:
+        for client in CLIENT_CACHE.values():
+            with ignored(Exception):
+                client.close()
         CLIENT_CACHE.clear()
 
 


### PR DESCRIPTION
Before references are dropped to open clients.

Should not rely on garbage collection: http://docs.paramiko.org/en/2.4/api/client.html#paramiko.client.SSHClient.close

Resolves #73 