### PR TITLE
Add test to ensure root user has no password.

### DIFF
--- a/usr/share/lib/ipa/tests/SLES/test_sles.yaml
+++ b/usr/share/lib/ipa/tests/SLES/test_sles.yaml
@@ -2,6 +2,7 @@ tests:
   - test_soft_reboot
   - test_sles_motd
   - test_sles_license
+  - test_sles_root_pass
   - test_hard_reboot
   - test_sles_hostname
   - test_sles_haveged

--- a/usr/share/lib/ipa/tests/SLES/test_sles_root_pass.py
+++ b/usr/share/lib/ipa/tests/SLES/test_sles_root_pass.py
@@ -1,0 +1,6 @@
+def test_sles_root_pass(host):
+    # Ensure root does not have a password
+    result = host.run(
+        "sudo getent shadow | grep '^root[^:]*:.\?:' | cut -d: -f1"
+    )
+    assert result.stdout.strip() == 'root'


### PR DESCRIPTION
- Check the shadow file to ensure root has no password. Command will return an empty string if root has a password.