### PR TITLE
Add optional timeout arg

### DIFF
--- a/ipa/ipa_azure.py
+++ b/ipa/ipa_azure.py
@@ -62,6 +62,7 @@ class AzureProvider(IpaProvider):
                  subnet_id=None,
                  test_dirs=None,
                  test_files=None,
+                 timeout=None,
                  vnet_name=None,
                  vnet_resource_group=None):
         """Initialize Azure Provider class."""
@@ -82,7 +83,8 @@ class AzureProvider(IpaProvider):
                                             results_dir,
                                             running_instance_id,
                                             test_dirs,
-                                            test_files)
+                                            test_files,
+                                            timeout)
 
         if subnet_id and not (vnet_name and vnet_resource_group):
             raise AzureProviderException(
@@ -430,7 +432,7 @@ class AzureProvider(IpaProvider):
             raise
         else:
             # Ensure VM is in the running state.
-            self._wait_on_instance('VM running')
+            self._wait_on_instance('VM running', timeout=self.timeout)
 
     def _process_image_id(self):
         """

--- a/ipa/ipa_controller.py
+++ b/ipa/ipa_controller.py
@@ -59,6 +59,7 @@ def test_image(provider_name,
                subnet_id=None,
                test_dirs=None,
                tests=None,
+               timeout=None,
                vnet_name=None,
                vnet_resource_group=None):
     """Creates a cloud provider instance and initiates testing."""
@@ -100,6 +101,7 @@ def test_image(provider_name,
         subnet_id=subnet_id,
         test_dirs=test_dirs,
         test_files=tests,
+        timeout=timeout,
         vnet_name=vnet_name,
         vnet_resource_group=vnet_resource_group
     )

--- a/ipa/ipa_ec2.py
+++ b/ipa/ipa_ec2.py
@@ -64,6 +64,7 @@ class EC2Provider(LibcloudProvider):
                  subnet_id=None,
                  test_dirs=None,
                  test_files=None,
+                 timeout=None,
                  vnet_name=None,  # Not used in EC2
                  vnet_resource_group=None  # Not used in EC2
                  ):
@@ -85,7 +86,8 @@ class EC2Provider(LibcloudProvider):
                                           results_dir,
                                           running_instance_id,
                                           test_dirs,
-                                          test_files)
+                                          test_files,
+                                          timeout)
         self.account_name = account_name
 
         if not self.account_name:
@@ -263,7 +265,10 @@ class EC2Provider(LibcloudProvider):
 
         instance = self.compute_driver.create_node(**kwargs)
 
-        self.compute_driver.wait_until_running([instance])
+        self.compute_driver.wait_until_running(
+            [instance],
+            timeout=self.timeout
+        )
         self.running_instance_id = instance.id
 
     def _set_image_id(self):

--- a/ipa/ipa_gce.py
+++ b/ipa/ipa_gce.py
@@ -65,6 +65,7 @@ class GCEProvider(LibcloudProvider):
                  subnet_id=None,
                  test_dirs=None,
                  test_files=None,
+                 timeout=None,
                  vnet_name=None,  # Not used in GCE
                  vnet_resource_group=None  # Not used in GCE
                  ):
@@ -85,7 +86,8 @@ class GCEProvider(LibcloudProvider):
                                           results_dir,
                                           running_instance_id,
                                           test_dirs,
-                                          test_files)
+                                          test_files,
+                                          timeout)
         self.service_account_file = (
             service_account_file or
             self._get_value(
@@ -226,7 +228,10 @@ class GCEProvider(LibcloudProvider):
                 )
             )
 
-        self.compute_driver.wait_until_running([instance])
+        self.compute_driver.wait_until_running(
+            [instance],
+            timeout=self.timeout
+        )
 
     def _set_image_id(self):
         """If existing image used get image id."""

--- a/ipa/ipa_libcloud.py
+++ b/ipa/ipa_libcloud.py
@@ -54,13 +54,16 @@ class LibcloudProvider(IpaProvider):
         """Start the instance."""
         instance = self._get_instance()
         self.compute_driver.ex_start_node(instance)
-        self.compute_driver.wait_until_running([instance])
+        self.compute_driver.wait_until_running(
+            [instance],
+            timeout=self.timeout
+        )
 
     def _stop_instance(self):
         """Stop the instance."""
         instance = self._get_instance()
         self.compute_driver.ex_stop_node(instance)
-        self._wait_on_instance('stopped')
+        self._wait_on_instance('stopped', timeout=self.timeout)
 
     def _terminate_instance(self):
         """Terminate the instance."""

--- a/ipa/ipa_utils.py
+++ b/ipa/ipa_utils.py
@@ -273,28 +273,30 @@ def get_ssh_client(ip,
                    ssh_private_key,
                    ssh_user='root',
                    port=22,
-                   attempts=3,
-                   timeout=10):
+                   timeout=600,
+                   wait_period=10):
     """Attempt to establish and test ssh connection."""
     if ip in CLIENT_CACHE:
         return CLIENT_CACHE[ip]
 
+    start = time.time()
+    end = start + timeout
+
     client = None
-    while attempts:
+    while time.time() < end:
         try:
             client = establish_ssh_connection(
                 ip,
                 ssh_private_key,
                 ssh_user,
                 port,
-                timeout=timeout
+                timeout=wait_period
             )
             execute_ssh_command(client, 'ls')
         except:  # noqa: E722
             if client:
                 client.close()
-            attempts -= 1
-            timeout += timeout
+            wait_period += wait_period
         else:
             CLIENT_CACHE[ip] = client
             return client

--- a/ipa/scripts/cli.py
+++ b/ipa/scripts/cli.py
@@ -210,6 +210,12 @@ def main(context, no_color):
     help='Directories to search for tests.'
 )
 @click.option(
+    '--timeout',
+    help='The time to wait when establishing an SSH '
+         'connection and for instances to change state.',
+    type=click.IntRange(min=1)
+)
+@click.option(
     '--vnet-name',
     help='Azure virtual network name to attach network interface.'
 )
@@ -248,6 +254,7 @@ def test(context,
          ssh_user,
          subnet_id,
          test_dirs,
+         timeout,
          vnet_name,
          vnet_resource_group,
          provider,
@@ -282,6 +289,7 @@ def test(context,
             subnet_id,
             test_dirs,
             tests,
+            timeout,
             vnet_name,
             vnet_resource_group
         )

--- a/man/man1/ipa-list.1
+++ b/man/man1/ipa-list.1
@@ -1,4 +1,4 @@
-.TH "IPA LIST" "1" "28-Mar-2018" "" "ipa list Manual"
+.TH "IPA LIST" "1" "31-May-2018" "" "ipa list Manual"
 .SH NAME
 ipa\-list \- Print a list of test files or test cases.
 .SH SYNOPSIS

--- a/man/man1/ipa-results-clear.1
+++ b/man/man1/ipa-results-clear.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS CLEAR" "1" "28-Mar-2018" "" "ipa results clear Manual"
+.TH "IPA RESULTS CLEAR" "1" "31-May-2018" "" "ipa results clear Manual"
 .SH NAME
 ipa\-results\-clear \- Clear the results from the history file.
 .SH SYNOPSIS

--- a/man/man1/ipa-results-delete.1
+++ b/man/man1/ipa-results-delete.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS DELETE" "1" "28-Mar-2018" "" "ipa results delete Manual"
+.TH "IPA RESULTS DELETE" "1" "31-May-2018" "" "ipa results delete Manual"
 .SH NAME
 ipa\-results\-delete \- Delete the specified history item from the...
 .SH SYNOPSIS

--- a/man/man1/ipa-results-list.1
+++ b/man/man1/ipa-results-list.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS LIST" "1" "28-Mar-2018" "" "ipa results list Manual"
+.TH "IPA RESULTS LIST" "1" "31-May-2018" "" "ipa results list Manual"
 .SH NAME
 ipa\-results\-list \- Display list of results history.
 .SH SYNOPSIS

--- a/man/man1/ipa-results-show.1
+++ b/man/man1/ipa-results-show.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS SHOW" "1" "28-Mar-2018" "" "ipa results show Manual"
+.TH "IPA RESULTS SHOW" "1" "31-May-2018" "" "ipa results show Manual"
 .SH NAME
 ipa\-results\-show \- Print test results info from provided results...
 .SH SYNOPSIS

--- a/man/man1/ipa-results.1
+++ b/man/man1/ipa-results.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS" "1" "28-Mar-2018" "" "ipa results Manual"
+.TH "IPA RESULTS" "1" "31-May-2018" "" "ipa results Manual"
 .SH NAME
 ipa\-results \- Process provided history log and results...
 .SH SYNOPSIS

--- a/man/man1/ipa-test.1
+++ b/man/man1/ipa-test.1
@@ -1,4 +1,4 @@
-.TH "IPA TEST" "1" "28-Mar-2018" "" "ipa test Manual"
+.TH "IPA TEST" "1" "31-May-2018" "" "ipa test Manual"
 .SH NAME
 ipa\-test \- Test image in the given framework using the...
 .SH SYNOPSIS
@@ -34,6 +34,9 @@ ipa history log file location. Default: ~/.config/ipa/.history
 .TP
 \fB\-i,\fP \-\-image\-id TEXT
 The ID of the image used for instance.
+.TP
+\fB\-\-inject\fP PATH
+Path to an injection yaml config file.
 .TP
 \fB\-t,\fP \-\-instance\-type TEXT
 Instance type to use for launching machine.
@@ -82,6 +85,9 @@ Subnet to launch the new instance into.
 .TP
 \fB\-\-test\-dirs\fP TEXT
 Directories to search for tests.
+.TP
+\fB\-\-timeout\fP INTEGER RANGE
+The time to wait when establishing an SSH connection and for instances to change state.
 .TP
 \fB\-\-vnet\-name\fP TEXT
 Azure virtual network name to attach network interface.

--- a/man/man1/ipa.1
+++ b/man/man1/ipa.1
@@ -1,4 +1,4 @@
-.TH "IPA" "1" "28-Mar-2018" "" "ipa Manual"
+.TH "IPA" "1" "31-May-2018" "" "ipa Manual"
 .SH NAME
 ipa \- Ipa provides a Python API and command line...
 .SH SYNOPSIS

--- a/tests/test_ipa_utils.py
+++ b/tests/test_ipa_utils.py
@@ -77,15 +77,21 @@ def test_utils_get_ssh_connection(mock_connect, mock_exec_cmd):
     ipa_utils.clear_cache()
 
 
+@patch.object(time, 'time')
 @patch.object(time, 'sleep')
 @patch.object(paramiko.SSHClient, 'connect')
-def test_utils_ssh_connect_exception(mock_connect, mock_sleep):
+def test_utils_ssh_connect_exception(mock_connect, mock_sleep, mock_time):
     """Test exception raised connecting to ssh."""
     mock_connect.side_effect = paramiko.ssh_exception.SSHException('ERROR!')
     mock_sleep.return_value = None
+    mock_time.side_effect = [0, 0, 2]
 
     with pytest.raises(IpaSSHException) as error:
-        ipa_utils.get_ssh_client(LOCALHOST, 'tests/data/ida_test')
+        ipa_utils.get_ssh_client(
+            LOCALHOST,
+            'tests/data/ida_test',
+            timeout=1
+        )
 
     assert str(error.value) == 'Attempt to establish SSH connection failed.'
     assert mock_connect.call_count > 0


### PR DESCRIPTION
Timeouts now based on time passed and not number of attempts. This allows for a single --timeout option to configure all timeouts.

- Bump default timeout length to 600 seconds (10 minutes) to better account for large instances.
- Add --timeout cli and configuration option.

Closes #85.