### PR TITLE
Add a test to wait on registration for on-demand images

### DIFF
--- a/usr/share/lib/ipa/tests/SLES/test_sles_on_demand.yaml
+++ b/usr/share/lib/ipa/tests/SLES/test_sles_on_demand.yaml
@@ -1,4 +1,5 @@
 tests:
+  - test_sles_wait_on_registration
   - test_update
   - test_sles_repos
   - test_sles_smt_reg

--- a/usr/share/lib/ipa/tests/SLES/test_sles_wait_on_registration.py
+++ b/usr/share/lib/ipa/tests/SLES/test_sles_wait_on_registration.py
@@ -1,0 +1,18 @@
+import time
+
+
+def test_sles_wait_on_registration(host):
+    start = time.time()
+    end = start + 600
+
+    while time.time() < end:
+        result = host.run('pgrep registercloud')
+
+        if not result.stdout.strip():
+            break
+        else:
+            time.sleep(10)
+    else:
+        raise Exception(
+            'Registration did not finish properly for on-demand instance.'
+        )


### PR DESCRIPTION
On-demand registration will take time to complete. Wait for the process to terminate before moving forward with tests.