### PR TITLE
Add azure tests to check billing tag in metadata.

### DIFF
--- a/usr/share/lib/ipa/tests/SLES/Azure/conftest.py
+++ b/usr/share/lib/ipa/tests/SLES/Azure/conftest.py
@@ -1,0 +1,14 @@
+import json
+import pytest
+
+
+@pytest.fixture()
+def get_azure_billing_tag(host):
+    def f():
+        result = host.run(
+            'sudo azuremetadata --tag'
+        )
+
+        data = json.loads(result.stdout.strip())
+        return data['billingTag']
+    return f

--- a/usr/share/lib/ipa/tests/SLES/Azure/test_sles_azure_billing_tag.py
+++ b/usr/share/lib/ipa/tests/SLES/Azure/test_sles_azure_billing_tag.py
@@ -1,0 +1,4 @@
+
+
+def test_sles_azure_billing_tag(get_azure_billing_tag):
+    assert get_azure_billing_tag()

--- a/usr/share/lib/ipa/tests/SLES/Azure/test_sles_azure_on_demand.yaml
+++ b/usr/share/lib/ipa/tests/SLES/Azure/test_sles_azure_on_demand.yaml
@@ -1,0 +1,2 @@
+tests:
+  - test_sles_azure_billing_tag


### PR DESCRIPTION
For on-demand instances the billingTag should be a string.