### PR TITLE
Using token normalize breaks region shortcode.

### DIFF
--- a/ipa/scripts/cli.py
+++ b/ipa/scripts/cli.py
@@ -166,7 +166,6 @@ def main(context, no_color):
     help='The provider specific config file location.'
 )
 @click.option(
-    '-r',
     '--region',
     help='Cloud provider region to test image.'
 )

--- a/man/man1/ipa-list.1
+++ b/man/man1/ipa-list.1
@@ -1,4 +1,4 @@
-.TH "IPA LIST" "1" "31-May-2018" "" "ipa list Manual"
+.TH "IPA LIST" "1" "20-Jun-2018" "" "ipa list Manual"
 .SH NAME
 ipa\-list \- Print a list of test files or test cases.
 .SH SYNOPSIS

--- a/man/man1/ipa-results-clear.1
+++ b/man/man1/ipa-results-clear.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS CLEAR" "1" "31-May-2018" "" "ipa results clear Manual"
+.TH "IPA RESULTS CLEAR" "1" "20-Jun-2018" "" "ipa results clear Manual"
 .SH NAME
 ipa\-results\-clear \- Clear the results from the history file.
 .SH SYNOPSIS

--- a/man/man1/ipa-results-delete.1
+++ b/man/man1/ipa-results-delete.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS DELETE" "1" "31-May-2018" "" "ipa results delete Manual"
+.TH "IPA RESULTS DELETE" "1" "20-Jun-2018" "" "ipa results delete Manual"
 .SH NAME
 ipa\-results\-delete \- Delete the specified history item from the...
 .SH SYNOPSIS

--- a/man/man1/ipa-results-list.1
+++ b/man/man1/ipa-results-list.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS LIST" "1" "31-May-2018" "" "ipa results list Manual"
+.TH "IPA RESULTS LIST" "1" "20-Jun-2018" "" "ipa results list Manual"
 .SH NAME
 ipa\-results\-list \- Display list of results history.
 .SH SYNOPSIS

--- a/man/man1/ipa-results-show.1
+++ b/man/man1/ipa-results-show.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS SHOW" "1" "31-May-2018" "" "ipa results show Manual"
+.TH "IPA RESULTS SHOW" "1" "20-Jun-2018" "" "ipa results show Manual"
 .SH NAME
 ipa\-results\-show \- Print test results info from provided results...
 .SH SYNOPSIS

--- a/man/man1/ipa-results.1
+++ b/man/man1/ipa-results.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS" "1" "31-May-2018" "" "ipa results Manual"
+.TH "IPA RESULTS" "1" "20-Jun-2018" "" "ipa results Manual"
 .SH NAME
 ipa\-results \- Process provided history log and results...
 .SH SYNOPSIS

--- a/man/man1/ipa-test.1
+++ b/man/man1/ipa-test.1
@@ -1,4 +1,4 @@
-.TH "IPA TEST" "1" "31-May-2018" "" "ipa test Manual"
+.TH "IPA TEST" "1" "20-Jun-2018" "" "ipa test Manual"
 .SH NAME
 ipa\-test \- Test image in the given framework using the...
 .SH SYNOPSIS
@@ -56,7 +56,7 @@ Do not include default test directories in search for tests.
 \fB\-\-provider\-config\fP TEXT
 The provider specific config file location.
 .TP
-\fB\-r,\fP \-\-region TEXT
+\fB\-\-region\fP TEXT
 Cloud provider region to test image.
 .TP
 \fB\-\-results\-dir\fP TEXT

--- a/man/man1/ipa.1
+++ b/man/man1/ipa.1
@@ -1,4 +1,4 @@
-.TH "IPA" "1" "31-May-2018" "" "ipa Manual"
+.TH "IPA" "1" "20-Jun-2018" "" "ipa Manual"
 .SH NAME
 ipa \- Ipa provides a Python API and command line...
 .SH SYNOPSIS


### PR DESCRIPTION
The token normalize function allows choice options to be case insensitive. However it also makes option codes case insensitive. Remove the -r short code for region which now overlaps with -R for running instance id.

Fixes #84 